### PR TITLE
Upgrade to v1.3.0 of build scripts, dry-run publish

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,7 +16,7 @@ on:
 jobs:
 
   pr-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-build.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-build.yml@v1.3.0
     #uses: ./.github/workflows/npm-packages-pr-build.yml
     with:
       always_increment_patch_version: false

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -19,7 +19,7 @@ on:
 jobs:
 
   npm-packages-pr-create-tag:
-    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-create-tag.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-create-tag.yml@v1.3.0
     #uses: ./.github/workflows/npm-packages-pr-create-tag.yml
     if: github.event.pull_request.merged == true
     secrets:

--- a/.github/workflows/version-tag-build-master.yml
+++ b/.github/workflows/version-tag-build-master.yml
@@ -15,12 +15,15 @@ on:
 jobs:
 
   version-tag-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-packages-release-on-tag.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-packages-release-on-tag.yml@v1.3.0
     #uses: ./.github/workflows/npm-packages-release-on-tag.yml
     secrets:
       myget_api_key: ${{ secrets.MYGET_DEPLOY_API_KEY_SECRET }}
+      npmjs_org_api_key: ${{ secrets.RITTERIM_NPMJS_PUBLISH_TOKEN }}
     with:
       allowed_branches: |
         master
       npm_package_name: platform-icons
       run_tests: false
+      npmjs_org_access_public: true
+      publish_to_npmjs_org: true


### PR DESCRIPTION
Do a dry-run publish to npmjs.org, but do a real release to the private registries.