### PR TITLE
Set always_increment_patch_version: true

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,6 +19,6 @@ jobs:
     uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-build.yml@v1.3.0
     #uses: ./.github/workflows/npm-packages-pr-build.yml
     with:
-      always_increment_patch_version: false
+      always_increment_patch_version: true
       npm_package_name: platform-icons
       run_tests: false

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -26,7 +26,7 @@ jobs:
       gh_actions_secret_passing_passphrase: ${{ secrets.ACTIONS_SECRET_PASSING_PASSPHRASE }}
       gh_app_private_key: ${{ secrets.RIMDEV_NPM_RELEASES_APP_PRIVATE_KEY }}
     with:
-      always_increment_patch_version: false
+      always_increment_patch_version: true
       gh_app_id: ${{ vars.RIMDEV_NPM_RELEASES_APP_APPID }}
       npm_package_name: platform-icons
       run_tests: false


### PR DESCRIPTION
With this setting, every PR (or merge) to the trunk branch will automatically bump the patch version and publish a new release tag.

The underlying workflows/actions (v1.3.0) have been updated to actually publish to the npmjs.org registry.

---

Example: Even without adding the "+semver:patch" label to this PR, the patch version is bumped.

<img width="867" alt="image" src="https://github.com/ritterim/platform-icons/assets/4880437/897ed9d7-a990-4557-a5e2-38ffbd357729">

