### PR TITLE
Trigger another build to test release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Platform Icons
+
 Separate package for [Platform UI](https://github.com/ritterim/platform-ui) Icons
+
 ## How to use
+
 ### CDN Usage
 - In your projects `<head>` section, include one of the following lines:
 


### PR DESCRIPTION
The push to NPM failed because we had the repo marked as private.

(This should cause a release of version 2.1.11 out to NPM.)