### PR TITLE
Use pull_request_target to properly create tags

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -11,7 +11,7 @@ on:
   # By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened.
   # We want to run on 'closed' to trigger, but we also have to check if it was merged.
   # That check is: if: github.event.pull_request.merged == true
-  pull_request:
+  pull_request_target:
     types: [ closed ]
     branches:
       - master


### PR DESCRIPTION
This should be safe-ish.

- The GITHUB_TOKEN is a read-only token.

- The secrets passed down into the call stack are not provided to any job steps that execute PR code.

- The job that uses the private key secret does not checkout the PR code.

- The job that consumes the write-capable token takes care to use "--ignore-scripts" on the "npm version" command.

- Inputs are pushed through bash environment variables instead of being used to construct command-lines. The values are also tested against restrictive regex patterns.