### PR TITLE
Upgrade to v1.4.0 of the build process

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,7 +16,7 @@ on:
 jobs:
 
   pr-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-build.yml@v1.3.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-build.yml@v1.4.0
     #uses: ./.github/workflows/npm-packages-pr-build.yml
     with:
       always_increment_patch_version: true

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -19,7 +19,7 @@ on:
 jobs:
 
   npm-packages-pr-create-tag:
-    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-create-tag.yml@v1.3.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-create-tag.yml@v1.4.0
     #uses: ./.github/workflows/npm-packages-pr-create-tag.yml
     if: github.event.pull_request.merged == true
     secrets:

--- a/.github/workflows/version-tag-build-master.yml
+++ b/.github/workflows/version-tag-build-master.yml
@@ -15,7 +15,7 @@ on:
 jobs:
 
   version-tag-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-packages-release-on-tag.yml@v1.3.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-packages-release-on-tag.yml@v1.4.0
     #uses: ./.github/workflows/npm-packages-release-on-tag.yml
     secrets:
       myget_api_key: ${{ secrets.MYGET_DEPLOY_API_KEY_SECRET }}


### PR DESCRIPTION
Some of the later actions were still back in our private repo.  That should now be sorted out.